### PR TITLE
🪲 Fix view error

### DIFF
--- a/src/Cannon.sol
+++ b/src/Cannon.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 import "forge-std/Vm.sol";
 
 library Cannon {
-    function getAddress(Vm vm, string memory name) external view returns (address) {
+    function getAddress(Vm vm, string memory name) external returns (address) {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/deployments/test/", name, ".json");
         bytes memory addr = vm.parseJson(vm.readFile(path), ".address");


### PR DESCRIPTION
When running `cannon test cannonfile.toml` I get the following error due to the `Vm.getAddress` invocation:
```
Compiler run failed:
Error (8961): Function cannot be declared as view because this expression (potentially) modifies the state.
 --> lib/cannon-std/src/Cannon.sol:7:30:
  |
7 |         string memory root = vm.projectRoot();
  |                              ^^^^^^^^^^^^^^^^

Error (8961): Function cannot be declared as view because this expression (potentially) modifies the state.
 --> lib/cannon-std/src/Cannon.sol:9:42:
  |
9 |         bytes memory addr = vm.parseJson(vm.readFile(path), ".address");
  |                                          ^^^^^^^^^^^^^^^^^

Error (8961): Function cannot be declared as view because this expression (potentially) modifies the state.
 --> lib/cannon-std/src/Cannon.sol:9:29:
  |
9 |         bytes memory addr = vm.parseJson(vm.readFile(path), ".address");
  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ```

The fix is simple - update the `getAddress` function to not be a view.